### PR TITLE
Clean up unused HL7 status helper

### DIFF
--- a/ps/HL7.ps1
+++ b/ps/HL7.ps1
@@ -141,33 +141,31 @@ function HL7_IN_INITIAL {
         if (-not $messageControlId) { throw "Message Control ID not found" }
 
         $updateQuery = @"
-UPDATE T_HL7_MESSAGE_IN 
+UPDATE T_HL7_MESSAGE_IN
 SET MESSAGE_TYPE = ?,
-    MESSAGE_CONTROL_ID = ?,
-    STATUS = 'P',
-    PROCESSED_DATE = ?
+    MESSAGE_CONTROL_ID = ?
 WHERE ENTRY_CODE = ?
 "@
         $params = @{
             MessageType = $messageType
             MessageControlId = $messageControlId
-            ProcessedDate = (Get-Date)
             EntryCode = $EntryCode
         }
-        
+
         Invoke-SqlQuery -Query $updateQuery -Parameters $params -Config $config -NonQuery
+        Update-HL7MessageStatus -EntryCode $EntryCode -Status 'P' -Config $config
         Create-LIMSLog "Successfully processed message $EntryCode ($messageControlId)"
         return $true
     }
     catch {
         Create-LIMSLog "Error processing message $EntryCode: $_"
-        $errorQuery = "UPDATE T_HL7_MESSAGE_IN SET STATUS = 'E', ERROR_MESSAGE = ?, PROCESSED_DATE = ? WHERE ENTRY_CODE = ?"
+        $errorQuery = "UPDATE T_HL7_MESSAGE_IN SET ERROR_MESSAGE = ? WHERE ENTRY_CODE = ?"
         $errorParams = @{
             ErrorMessage = $_.Exception.Message
-            ProcessedDate = (Get-Date)
             EntryCode = $EntryCode
         }
         Invoke-SqlQuery -Query $errorQuery -Parameters $errorParams -Config $config -NonQuery
+        Update-HL7MessageStatus -EntryCode $EntryCode -Status 'E' -Config $config
         throw
     }
     finally {
@@ -175,4 +173,4 @@ WHERE ENTRY_CODE = ?
     }
 }
 
-Export-ModuleMember -Function SCHED_HL7_IN_MSG_READ, HL7_CREATE_MESSAGE, HL7_IN_INITIAL
+Export-ModuleMember -Function SCHED_HL7_IN_MSG_READ, HL7_CREATE_MESSAGE, HL7_IN_INITIAL, Update-HL7MessageStatus

--- a/ps/HL7Wrappers.ps1
+++ b/ps/HL7Wrappers.ps1
@@ -121,3 +121,4 @@ function Update-HL7MessageStatus {
     }
     Invoke-SqlQuery -Query $query -Parameters $params -Config $config -NonQuery
 }
+

--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -11,3 +11,12 @@ Describe 'HL7_CREATE_MESSAGE' {
         { HL7_CREATE_MESSAGE -HL7MessageEntryCode '1' -HL7InInitialStatus 'P' } | Should -Not -Throw
     }
 }
+
+Describe 'Update-HL7MessageStatus' {
+    It 'Calls Invoke-SqlQuery to update status' {
+        Mock -CommandName Invoke-SqlQuery -MockWith { $script:called = $true }
+        { Update-HL7MessageStatus -EntryCode '1' -Status 'P' -Config @{ ConfigPath = '' } } | Should -Not -Throw
+        $called | Should -BeTrue
+    }
+}
+


### PR DESCRIPTION
## Summary
- integrate the Update-HL7MessageStatus helper back into HL7 message processing
- export Update-HL7MessageStatus from module
- test Update-HL7MessageStatus behavior

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester tests/test.ps1 -EnableExit"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa14a1308832795ed2f5fb4d8837a