### PR TITLE
Fix config path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This repository contains PowerShell scripts for processing HL7 messages.
 ## Configuration
 
 `ps/HL7.ps1` requires a JSON file with ODBC connection details. By default it
-looks for `config/Settings.json`. Override this path with the `HL7ConfigPath`
-environment variable.
+looks for `config/Settings.json`. Set the `HL7ConfigPath` environment variable
+to point to a different configuration file if needed.
 
 A sample configuration file is provided at `samples/Settings.json`. Copy it to
 the `config` directory and edit the DSN, UID and PWD values for your
@@ -14,6 +14,19 @@ environment.
 
 Log files are written to `logs/HL7Processor_<date>.log` by default. You can
 change the log directory by setting the `HL7LogPath` environment variable.
+
+## Usage
+
+`ps/HL7.ps1` acts as a PowerShell script module. Load it with
+`Import-Module` so its exported functions are available:
+
+```powershell
+Import-Module ./ps/HL7.ps1
+```
+
+Executing the file directly may raise an error from
+`Export-ModuleMember` because that cmdlet only runs inside a module
+scope.
 
 ## Tests
 

--- a/ps/HL7.ps1
+++ b/ps/HL7.ps1
@@ -1,9 +1,21 @@
 . "$PSScriptRoot/HL7Wrappers.ps1"
 
-# Configuration with paths relative to the script location
+# Configuration with paths relative to the script location. These can be
+# overridden using the HL7ConfigPath and HL7LogPath environment variables.
+$configPath = $env:HL7ConfigPath
+if (-not $configPath) {
+    $configPath = "$PSScriptRoot/../config/Settings.json"
+}
+
+$logDir = $env:HL7LogPath
+if (-not $logDir) {
+    $logDir = "$PSScriptRoot/../logs"
+}
+$logPath = Join-Path $logDir "HL7Processor_$(Get-Date -Format 'yyyyMMdd').log"
+
 $config = @{
-    ConfigPath = "$PSScriptRoot/../Config/settings.json"
-    LogPath = "$PSScriptRoot/../Logs/HL7Processor_$(Get-Date -Format 'yyyyMMdd').log"
+    ConfigPath = $configPath
+    LogPath = $logPath
     DefaultStartID = 100000
     MaxRetryAttempts = 3
     RetryDelaySeconds = 5


### PR DESCRIPTION
## Summary
- support `HL7ConfigPath` and `HL7LogPath` environment variables again
- clarify README about overriding `config/Settings.json`

## Testing
- `./run-tests.sh` *(fails: pwsh not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad737abfc832795817338a94b51a3