### PR TITLE
Fix HL7 filename generation

### DIFF
--- a/ps/HL7.ps1
+++ b/ps/HL7.ps1
@@ -71,7 +71,7 @@ WHERE HL7facilityDetails.ACTIVE = 'T' AND facility.Z_HL7 = 'T'
                         continue
                     }
                     
-                    $dateTimeHL7Out = HL7-FormatDate (Get-Date)
+                    $dateTimeHL7Out = Get-Date -Format 'yyyyMMddHHmmssfff'
                     $newFileName = "$processedDirectory$($dateTimeHL7Out)-$orderNumber-$sendingApplication.txt"
                     Rename-File $file.FullName $newFileName
                     Create-LIMSLog -Message "Processed file: $($file.Name) -> $newFileName" -Config $config

--- a/ps/HL7Wrappers.ps1
+++ b/ps/HL7Wrappers.ps1
@@ -68,7 +68,17 @@ function Rename-File {
     )
     $dir = Split-Path $New
     if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir | Out-Null }
-    Move-Item -Path $Old -Destination $New
+    $destination = $New
+    if (Test-Path $destination) {
+        $base = [System.IO.Path]::GetFileNameWithoutExtension($New)
+        $ext = [System.IO.Path]::GetExtension($New)
+        $counter = 1
+        while (Test-Path $destination) {
+            $destination = Join-Path $dir "$base`_$counter$ext"
+            $counter++
+        }
+    }
+    Move-Item -Path $Old -Destination $destination
 }
 
 function Create-LIMSLog {


### PR DESCRIPTION
## Summary
- add millisecond timestamp when generating HL7 output filenames
- make `Rename-File` avoid collisions by auto-incrementing the destination name

## Testing
- `./run-tests.sh` *(fails: pwsh not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae64b1d348327b01f3b3869fbf916