### PR TITLE
Handle duplicate filenames earlier in Rename-File

### DIFF
--- a/ps/HL7Wrappers.ps1
+++ b/ps/HL7Wrappers.ps1
@@ -98,34 +98,24 @@ function Rename-File {
     $target = $New
     $attempt = 0
 
-    while ($true) {
-        try {
-            Move-Item -Path $Old -Destination $target -Force -ErrorAction Stop
-            Write-Host "Successfully moved to: $target" -ForegroundColor DarkGray
-            return $target
-        }
-        catch [System.IO.IOException] {
-            if ($_.Exception.Message -match 'already exists') {
-                $attempt++
-                $baseName = [System.IO.Path]::GetFileNameWithoutExtension($New)
-                $extension = [System.IO.Path]::GetExtension($New)
-                $target = Join-Path $dir "${baseName}_$attempt$extension"
-                Write-Host "Destination exists, retrying with new name: $(Split-Path $target -Leaf)" -ForegroundColor Yellow
-                continue
-            }
-            else {
-                $msg = "FILE MOVE ERROR: $_"
-                Write-Host $msg -ForegroundColor Red
-                Create-LIMSLog -Message $msg -Config $config
-                throw
-            }
-        }
-        catch {
-            $msg = "FILE MOVE ERROR: $_"
-            Write-Host $msg -ForegroundColor Red
-            Create-LIMSLog -Message $msg -Config $config
-            throw
-        }
+    while (Test-Path $target) {
+        $attempt++
+        $baseName  = [System.IO.Path]::GetFileNameWithoutExtension($New)
+        $extension = [System.IO.Path]::GetExtension($New)
+        $target    = Join-Path $dir "${baseName}_$attempt$extension"
+        Write-Host "Destination exists, using new name: $(Split-Path $target -Leaf)" -ForegroundColor Yellow
+    }
+
+    try {
+        Move-Item -Path $Old -Destination $target -Force -ErrorAction Stop
+        Write-Host "Successfully moved to: $target" -ForegroundColor DarkGray
+        return $target
+    }
+    catch {
+        $msg = "FILE MOVE ERROR: $_"
+        Write-Host $msg -ForegroundColor Red
+        Create-LIMSLog -Message $msg -Config $config
+        throw
     }
 }
 

--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -20,3 +20,18 @@ Describe 'Update-HL7MessageStatus' {
     }
 }
 
+Describe 'Rename-File' {
+    It 'Generates unique name when destination exists' {
+        $src  = New-TemporaryFile
+        Set-Content -Path $src -Value 'a'
+
+        $dest = New-TemporaryFile
+        Set-Content -Path $dest -Value 'b'
+
+        $result = Rename-File -Old $src -New $dest
+
+        Test-Path $result | Should -BeTrue
+        $result | Should -Not -Be $dest
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle existing destination names in `Rename-File` before moving
- add test for `Rename-File` collision logic

## Testing
- `./run-tests.sh` *(fails: pwsh not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b230db6ec8327b042d41826af3d4d