### PR TITLE
Improve file rename logging

### DIFF
--- a/ps/HL7.ps1
+++ b/ps/HL7.ps1
@@ -85,7 +85,7 @@ WHERE HL7facilityDetails.ACTIVE = 'T' AND facility.Z_HL7 = 'T'
                         Write-Host $msg -ForegroundColor Yellow
                         Create-LIMSLog -Message $msg -Config $config
                         $errorFileName = Join-Path $errorDirectory $file.Name
-                        $movedFile = Rename-File $file.FullName $errorFileName
+                        $movedFile = Rename-File $file.FullName $errorFileName -Config $config
                         Write-Host "Moved to error directory: $movedFile" -ForegroundColor Yellow
                         continue
                     }
@@ -93,7 +93,7 @@ WHERE HL7facilityDetails.ACTIVE = 'T' AND facility.Z_HL7 = 'T'
                     # Use helper to get consistent timestamp with millisecond precision
                     $dateTimeHL7Out = HL7-FormatDate (Get-Date)
                     $newFileName = Join-Path $processedDirectory "$($dateTimeHL7Out)-$orderNumber-$sendingApplication.txt"
-                    $movedFile = Rename-File $file.FullName $newFileName
+                    $movedFile = Rename-File $file.FullName $newFileName -Config $config
                     $msg = "Processed: $($file.Name) -> $(Split-Path $movedFile -Leaf)"
                     Write-Host $msg -ForegroundColor Green
                     Create-LIMSLog -Message $msg -Config $config
@@ -200,7 +200,7 @@ function HL7_CREATE_MESSAGE {
         if ($HL7String) {
             $fileName = "$PSScriptRoot/../samples/out_${HL7MessageEntryCode}.hl7"
             $tempFile = New-TemporaryFile
-            $finalPath = Rename-File -Old $tempFile -New $fileName
+            $finalPath = Rename-File -Old $tempFile -New $fileName -Config $config
             Set-Content -Path $finalPath -Value $HL7String
             $msg = "Created output file: $(Split-Path $finalPath -Leaf)"
             Write-Host $msg -ForegroundColor Green

--- a/ps/HL7Wrappers.ps1
+++ b/ps/HL7Wrappers.ps1
@@ -84,7 +84,8 @@ function Get-FileContents {
 function Rename-File {
     param(
         [string]$Old,
-        [string]$New
+        [string]$New,
+        [hashtable]$Config = $null
     )
 
     Write-Verbose "Attempting to move file: $Old -> $New"
@@ -104,6 +105,7 @@ function Rename-File {
         try {
             Move-Item -Path $Old -Destination $target -Force -ErrorAction Stop
             Write-Host "Successfully moved to: $target" -ForegroundColor DarkGray
+            if ($Config) { Create-LIMSLog -Message "moved to $target" -Config $Config }
             return $target
         }
         catch [System.IO.IOException] {
@@ -117,19 +119,20 @@ function Rename-File {
                     $target = Join-Path $dir "${baseName}_${attempt}${extension}"
                 }
                 Write-Host "Destination exists, retrying with new name: $(Split-Path $target -Leaf)" -ForegroundColor Yellow
+                if ($Config) { Create-LIMSLog -Message "destination exists; renamed to $(Split-Path $target -Leaf)" -Config $Config }
                 continue
             }
             else {
                 $msg = "FILE MOVE ERROR: $_"
                 Write-Host $msg -ForegroundColor Red
-                Create-LIMSLog -Message $msg -Config $config
+                if ($Config) { Create-LIMSLog -Message $msg -Config $Config }
                 throw
             }
         }
         catch {
             $msg = "FILE MOVE ERROR: $_"
             Write-Host $msg -ForegroundColor Red
-            Create-LIMSLog -Message $msg -Config $config
+            if ($Config) { Create-LIMSLog -Message $msg -Config $Config }
             throw
         }
     }


### PR DESCRIPTION
## Summary
- better log handling during file renames
- propagate config object to Rename-File calls

## Testing
- `./run-tests.sh` *(fails: pwsh not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b3b7d0aa8832782ac77d5abbaa455